### PR TITLE
Commerce product revision table name adjustment.

### DIFF
--- a/exo_form/exo_form.module
+++ b/exo_form/exo_form.module
@@ -944,7 +944,7 @@ function exo_form_form_revision_overview_form_alter(&$form, FormStateInterface $
   $target = $form['commerce_product_revisions_table'] ?? $form['node_revisions_table'];
 
   foreach (Element::children($target) as $key) {
-    $element = &$form['node_revisions_table'][$key];
+    $element = &$target[$key];
     $element['select_column_one']['#exo_form_default'] = TRUE;
     $element['select_column_two']['#exo_form_default'] = TRUE;
   }

--- a/exo_form/exo_form.module
+++ b/exo_form/exo_form.module
@@ -941,7 +941,9 @@ function exo_form_field_widget_date_recur_modular_sierra_form_alter(&$element, F
  * Implements hook_form_FORM_ID_alter().
  */
 function exo_form_form_revision_overview_form_alter(&$form, FormStateInterface $form_state) {
-  foreach (Element::children($form['node_revisions_table']) as $key) {
+  $target = $form['commerce_product_revisions_table'] ?? $form['node_revisions_table'];
+
+  foreach (Element::children($target) as $key) {
     $element = &$form['node_revisions_table'][$key];
     $element['select_column_one']['#exo_form_default'] = TRUE;
     $element['select_column_two']['#exo_form_default'] = TRUE;


### PR DESCRIPTION
Commerce products have their own revision table name of ‘commerce_product_revisions_table’.

Added a check to account for either a commerce product or node.