### PR TITLE
Drupal 10 support started for additional submodules

### DIFF
--- a/exo_asset/exo_asset.info.yml
+++ b/exo_asset/exo_asset.info.yml
@@ -1,7 +1,7 @@
 name: 'eXo Asset'
 type: module
 description: 'Provides an enhanced media entity that combines both image and video.'
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.8 || ^9 || ^10
 package: 'eXo'
 dependencies:
   - exo

--- a/exo_asset/src/Form/ExoAssetForm.php
+++ b/exo_asset/src/Form/ExoAssetForm.php
@@ -46,7 +46,7 @@ class ExoAssetForm extends ContentEntityForm {
       $entity->setNewRevision();
 
       // If a new revision is created, save the current user as revision author.
-      $entity->setRevisionCreationTime(REQUEST_TIME);
+      $entity->setRevisionCreationTime(\Drupal::time()->getRequestTime());
       $entity->setRevisionUserId(\Drupal::currentUser()->id());
     }
     else {

--- a/exo_asset/src/Form/ExoAssetRevisionRevertForm.php
+++ b/exo_asset/src/Form/ExoAssetRevisionRevertForm.php
@@ -140,7 +140,7 @@ class ExoAssetRevisionRevertForm extends ConfirmFormBase {
   protected function prepareRevertedRevision(ExoAssetInterface $revision, FormStateInterface $form_state) {
     $revision->setNewRevision();
     $revision->isDefaultRevision(TRUE);
-    $revision->setRevisionCreationTime(REQUEST_TIME);
+    $revision->setRevisionCreationTime(\Drupal::time()->getRequestTime());
 
     return $revision;
   }

--- a/exo_asset/src/Form/ExoAssetRevisionRevertTranslationForm.php
+++ b/exo_asset/src/Form/ExoAssetRevisionRevertTranslationForm.php
@@ -107,7 +107,7 @@ class ExoAssetRevisionRevertTranslationForm extends ExoAssetRevisionRevertForm {
 
     $latest_revision_translation->setNewRevision();
     $latest_revision_translation->isDefaultRevision(TRUE);
-    $revision->setRevisionCreationTime(REQUEST_TIME);
+    $revision->setRevisionCreationTime(\Drupal::time()->getRequestTime());
 
     return $latest_revision_translation;
   }

--- a/exo_entity_browser/exo_entity_browser.info.yml
+++ b/exo_entity_browser/exo_entity_browser.info.yml
@@ -1,7 +1,7 @@
 name: 'eXo Entity Browser'
 type: module
 description: 'Provides entity browser enhancements.'
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.8 || ^9 || ^10
 package: 'eXo'
 dependencies:
   - exo_modal

--- a/exo_entity_browser/src/Plugin/EntityBrowser/Display/ExoModal.php
+++ b/exo_entity_browser/src/Plugin/EntityBrowser/Display/ExoModal.php
@@ -9,7 +9,8 @@ use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\exo_modal\Ajax\ExoModalOpenCommand;
 use Drupal\Core\Entity\EntityInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
 
 /**
  * Presents entity browser in an Modal.
@@ -113,10 +114,11 @@ class ExoModal extends Modal {
    * Intercepts default response and injects response that will trigger JS to
    * propagate selected entities upstream.
    *
-   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   * 
    *   Response event.
    */
-  public function propagateSelection(FilterResponseEvent $event) {
+  public function propagateSelection(ResponseEvent $event) {
     $render = [
       'labels' => [
         '#markup' => 'Labels: ' . implode(', ', array_map(function (EntityInterface $item) {

--- a/exo_image/exo_image.info.yml
+++ b/exo_image/exo_image.info.yml
@@ -2,6 +2,6 @@ name: 'eXo Image (deprecated)'
 type: module
 description: 'Provides image handling improvements.'
 package: 'eXo'
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.8 || ^9 || ^10
 lifecycle: deprecated
 lifecycle_link: 'https://www.merriam-webster.com/dictionary/deprecate'

--- a/exo_paragraphs/exo_paragraphs.info.yml
+++ b/exo_paragraphs/exo_paragraphs.info.yml
@@ -2,7 +2,7 @@ name: 'eXo Paragraphs'
 type: module
 description: 'Provides paragraphs enhancements.'
 package: 'eXo'
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.8 || ^9 || ^10
 dependencies:
   - exo
   - paragraphs

--- a/exo_splash/exo_splash.info.yml
+++ b/exo_splash/exo_splash.info.yml
@@ -1,7 +1,7 @@
 name: 'eXo Splash'
 type: module
 description: 'Provides a splash screen on first visit to the site.'
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^8.8 || ^9 || ^10
 package: 'eXo'
 dependencies:
   - exo


### PR DESCRIPTION
Drupal 10 support for submodules:

- exo_asset
- exo_paragraphs
- exo_entity_browser
- exo_image (deprecated)
- exo_splash