### PR TITLE
Commerce cart quantity field.

### DIFF
--- a/exo_form/src/Plugin/views/field/EditQuantity.php
+++ b/exo_form/src/Plugin/views/field/EditQuantity.php
@@ -24,7 +24,9 @@ class EditQuantity extends CommerceEditQuantity {
     parent::viewsForm($form, $form_state);
 
     foreach ($this->view->result as $row_index => $row) {
-      $form[$this->options['id']][$row_index]['#type'] = 'exo_number';
+      if (!$row->_relationship_entities['order_items']->isLocked()) {
+        $form[$this->options['id']][$row_index]['#type'] = 'exo_number';
+      }
     }
   }
 


### PR DESCRIPTION
The EditQuantity class is extended in order to apply an exo_number field to the cart quantity field.

If an order item is locked, this field allows the quantity to be changed and cart updated, effectively violating the lock.

This checks if the order item is locked before modifying the field type.