### PR TITLE
dealing with Trait 'Drupal\Core\Access\RefinableDependentAccessTrait'…

### DIFF
--- a/exo_alchemist/src/Controller/ExoFieldParentsFormTrait.php
+++ b/exo_alchemist/src/Controller/ExoFieldParentsFormTrait.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\exo_alchemist\Controller;
 
-use Drupal\Core\Access\RefinableDependentAccessTrait;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -16,7 +15,6 @@ use Drupal\exo_alchemist\Plugin\ExoComponentFieldFormInterface;
 trait ExoFieldParentsFormTrait {
 
   use ExoFieldParentsTrait;
-  use RefinableDependentAccessTrait;
 
   /**
    * The entity type manager.

--- a/exo_alchemist/src/Controller/ExoFieldParentsTrait.php
+++ b/exo_alchemist/src/Controller/ExoFieldParentsTrait.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\exo_alchemist\Controller;
 
+use Drupal\Core\Access\AccessibleInterface;
 use Drupal\Core\Access\RefinableDependentAccessInterface;
-use Drupal\Core\Access\RefinableDependentAccessTrait;
 use Drupal\block_content\BlockContentInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
@@ -14,7 +14,12 @@ use Drupal\layout_builder\Plugin\Block\InlineBlock;
  */
 trait ExoFieldParentsTrait {
 
-  use RefinableDependentAccessTrait;
+  /**
+   * The access dependency.
+   *
+   * @var \Drupal\Core\Access\AccessibleInterface|null
+   */
+  protected $accessDependency;
 
   /**
    * The entity type manager.
@@ -279,6 +284,42 @@ trait ExoFieldParentsTrait {
       $this->exoComponentManager = \Drupal::service('plugin.manager.exo_component');
     }
     return $this->exoComponentManager;
+  }
+
+  /**
+   * Sets the access dependency.
+   *
+   * @param \Drupal\Core\Access\AccessibleInterface $access_dependency
+   *   The object upon which access depends.
+   *
+   * @return $this
+   */
+  public function setAccessDependency(AccessibleInterface $access_dependency) {
+    $this->accessDependency = $access_dependency;
+    return $this;
+  }
+
+  /**
+   * Gets the access dependency.
+   *
+   * @return \Drupal\Core\Access\AccessibleInterface|null
+   *   The access dependency, or NULL if none is set.
+   */
+  public function getAccessDependency() {
+    return $this->accessDependency;
+  }
+
+  /**
+   * Adds an access dependency.
+   *
+   * @param \Drupal\Core\Access\AccessibleInterface $access_dependency
+   *   The object upon which access depends.
+   *
+   * @return $this
+   */
+  public function addAccessDependency(AccessibleInterface $access_dependency) {
+    $this->accessDependency = $access_dependency;
+    return $this;
   }
 
 }

--- a/exo_alchemist/src/ExoComponentRepository.php
+++ b/exo_alchemist/src/ExoComponentRepository.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\exo_alchemist;
 
+use Drupal\Core\Access\AccessibleInterface;
 use Drupal\Core\Access\RefinableDependentAccessInterface;
-use Drupal\Core\Access\RefinableDependentAccessTrait;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\layout_builder\Plugin\Block\InlineBlock;
@@ -22,7 +22,13 @@ use Drupal\layout_builder\SectionComponent;
  * The eXo component repository.
  */
 class ExoComponentRepository {
-  use RefinableDependentAccessTrait;
+
+  /**
+   * The access dependency.
+   *
+   * @var \Drupal\Core\Access\AccessibleInterface|null
+   */
+  protected $accessDependency;
 
   /**
    * Drupal\exo_alchemist\ExoComponentManager definition.
@@ -361,6 +367,42 @@ class ExoComponentRepository {
    */
   public static function sortComponents(SectionComponent $a, SectionComponent $b) {
     return $a->getWeight() - $b->getWeight();
+  }
+
+  /**
+   * Sets the access dependency.
+   *
+   * @param \Drupal\Core\Access\AccessibleInterface $access_dependency
+   *   The object upon which access depends.
+   *
+   * @return $this
+   */
+  public function setAccessDependency(AccessibleInterface $access_dependency) {
+    $this->accessDependency = $access_dependency;
+    return $this;
+  }
+
+  /**
+   * Gets the access dependency.
+   *
+   * @return \Drupal\Core\Access\AccessibleInterface|null
+   *   The access dependency, or NULL if none is set.
+   */
+  public function getAccessDependency() {
+    return $this->accessDependency;
+  }
+
+  /**
+   * Adds an access dependency.
+   *
+   * @param \Drupal\Core\Access\AccessibleInterface $access_dependency
+   *   The object upon which access depends.
+   *
+   * @return $this
+   */
+  public function addAccessDependency(AccessibleInterface $access_dependency) {
+    $this->accessDependency = $access_dependency;
+    return $this;
   }
 
 }

--- a/exo_imagine/src/Entity/ExoImagineStyle.php
+++ b/exo_imagine/src/Entity/ExoImagineStyle.php
@@ -56,7 +56,7 @@ class ExoImagineStyle implements ExoImagineStyleInterface {
    */
   public function getStyle() {
     $style = $this->style;
-    while (is_a($style, get_class())) {
+    while ($style instanceof self) {
       /** @var \Drupal\exo_imagine\Entity\ExoImagineStyleInterface $style */
       $style = $style->getStyle();
     }


### PR DESCRIPTION
Accidentally didn't do separate commits for these 2 issues, but the one for an annoying non-fatal warning for "get_class()" being deprecated in php 8.3 is pretty simple. 

The second change is that RefinableDependentAccessTrait was taken out  of Drupal 11 so what we gotta do is just add in the methods that it used to use to the classes that previously tried to use, and then there was like a third file where it was included but never really used 