### PR TITLE
Revision ID constraint violation error in Accordion

### DIFF
--- a/exo_alchemist/src/Plugin/ExoComponentField/Sequence.php
+++ b/exo_alchemist/src/Plugin/ExoComponentField/Sequence.php
@@ -186,9 +186,11 @@ class Sequence extends EntityReferenceBase {
           foreach ($child_definition->getFields() as $field) {
             $this->exoComponentManager()->onDraftUpdateLayoutBuilderEntity($child_definition, $item->entity);
           }
+          $revision_id = $item->entity->getRevisionId(); // if no revision id this is null
           $item->entity->enforceIsNew();
           $item->setValue([
             'target_id' => NULL,
+            'target_revision_id' => $revision_id,
             'entity' => $item->entity,
           ]);
         }


### PR DESCRIPTION
Deleting a sequence item from an Accordion component was causing a database constraint error when trying to save the layout, adding a revision ID in the deep serialize function in Sequence.php seems to fix this error