### PR TITLE
Trying to solve the deleting and saving sequence items db constraint

### DIFF
--- a/exo_alchemist/src/Controller/ExoFieldCloneController.php
+++ b/exo_alchemist/src/Controller/ExoFieldCloneController.php
@@ -114,7 +114,16 @@ class ExoFieldCloneController implements ContainerInjectionInterface {
           $clone_items = clone $items;
           $items->setValue(NULL);
           foreach ($clone_items as $item_delta => $item) {
-            $items->appendItem($item->getValue());
+            $value = $item->getValue();
+            // Preserve target_revision_id when copying so entity_reference_revisions
+            // constraint is satisfied (clone+remove can otherwise drop it).
+            if (!empty($value['target_id']) && empty($value['target_revision_id']) && !empty($value['entity'])) {
+              $ref = $value['entity'];
+              if ($ref instanceof \Drupal\Core\Entity\RevisionableInterface && $ref->getRevisionId()) {
+                $value['target_revision_id'] = $ref->getRevisionId();
+              }
+            }
+            $items->appendItem($value);
             if ($field_delta === $item_delta) {
               // Set new path.
               $updated_path = explode('.', $updated_path);
@@ -126,6 +135,7 @@ class ExoFieldCloneController implements ContainerInjectionInterface {
               if ($entity && $entity->getEntityTypeId() == ExoComponentManager::ENTITY_TYPE) {
                 $item_definition = $this->exoComponentManager->getEntityBundleComponentDefinition($entity->type->entity);
                 $value['target_id'] = NULL;
+                unset($value['target_revision_id']);
                 $value['entity'] = $this->exoComponentManager->cloneEntity($item_definition, $entity);
               }
               $items->appendItem($value);

--- a/exo_alchemist/src/Plugin/ExoComponentField/Sequence.php
+++ b/exo_alchemist/src/Plugin/ExoComponentField/Sequence.php
@@ -333,6 +333,27 @@ class Sequence extends EntityReferenceBase {
   public function onPreSaveLayoutBuilderEntity(FieldItemListInterface $items, EntityInterface $parent_entity) {
     parent::onPreSaveLayoutBuilderEntity($items, $parent_entity);
     $component = $this->getComponentDefinition();
+    $target_type = $items->getFieldDefinition()->getFieldStorageDefinition()->getSetting('target_type');
+    $storage = \Drupal::entityTypeManager()->getStorage($target_type);
+    // Ensure every item has target_revision_id when target_id is set, so
+    // EntityReferenceRevisionsItem::preSave() can load the entity and run.
+    foreach ($items as $delta => $item) {
+      if (!empty($item->target_id) && empty($item->target_revision_id)) {
+        $entity = $item->entity ?? $storage->load($item->target_id);
+        if ($entity && $entity instanceof RevisionableInterface) {
+          $revision_id = $entity->getRevisionId();
+          // If in-memory entity has no revision (e.g. setNewRevision() was called),
+          // load from storage so we never write NULL.
+          if (empty($revision_id) && $entity->id()) {
+            $loaded = $storage->load($entity->id());
+            $revision_id = $loaded ? $loaded->getRevisionId() : NULL;
+          }
+          if (!empty($revision_id)) {
+            $item->set('target_revision_id', $revision_id);
+          }
+        }
+      }
+    }
     foreach ($items as $delta => $item) {
       $component->addParentFieldDelta($this->getFieldDefinition(), $delta);
       $entity = $item->entity;


### PR DESCRIPTION
Guess I didn't test enough last pull request but I tested the heck out of this one! Deleting items from a component such as accordion can still trigger a database constraint violation where the target_revision_id is null, so this attempts to fix