### PR TITLE
Warnings for missing schema when saving an exo_list

### DIFF
--- a/exo_list_builder/config/schema/exo_entity_list.schema.yml
+++ b/exo_list_builder/config/schema/exo_entity_list.schema.yml
@@ -39,6 +39,8 @@ exo_list_builder.exo_entity_list.*:
     limit_options:
       type: sequence
       label: 'Limit Options'
+      sequence:
+        type: integer
     offset:
       type: integer
       label: 'Offset'
@@ -49,7 +51,8 @@ exo_list_builder.exo_entity_list.*:
         type: mapping
         mapping:
           settings:
-            type: mapping
+            type: ignore
+            label: 'Settings'
     sorts:
       type: sequence
       label: Sorts
@@ -57,7 +60,8 @@ exo_list_builder.exo_entity_list.*:
         type: mapping
         mapping:
           settings:
-            type: mapping
+            type: ignore
+            label: 'Settings'
     sort:
       type: string
       label: Default sort field
@@ -89,7 +93,8 @@ exo_list_builder.exo_entity_list.*:
                 type: string
                 label: 'Element Type'
               settings:
-                type: mapping
+                type: ignore
+                label: 'Settings'
               toggle:
                 type: boolean
                 label: 'Toggleable'
@@ -99,6 +104,33 @@ exo_list_builder.exo_entity_list.*:
               wrapper:
                 type: string
                 label: 'Wrapper'
+              align:
+                type: string
+                label: 'Align'
+              size:
+                type: string
+                label: 'Size'
+              group_by:
+                type: boolean
+                label: 'Group By'
+              group_by_sort:
+                type: string
+                label: 'Group By Sort'
+              sort:
+                type: string
+                label: 'Sort'
+              sort_asc_label:
+                type: string
+                label: 'Sort Ascending Label'
+              sort_desc_label:
+                type: string
+                label: 'Sort Descending Label'
+              sort_natsort:
+                type: boolean
+                label: 'Natural Sort'
+              sort_secondary:
+                type: boolean
+                label: 'Secondary Sort'
           filter:
             type: mapping
             mapping:
@@ -106,12 +138,14 @@ exo_list_builder.exo_entity_list.*:
                 type: string
                 label: 'Filter Type'
               settings:
-                type: mapping
+                type: ignore
+                label: 'Settings'
           weight:
             type: integer
             label: 'Weight'
     settings:
-      type: mapping
+      type: ignore
+      label: 'Settings'
     weight:
       type: integer
       label: 'Weight'

--- a/exo_list_builder/src/Entity/EntityList.php
+++ b/exo_list_builder/src/Entity/EntityList.php
@@ -334,6 +334,16 @@ class EntityList extends ConfigEntityBase implements EntityListInterface {
   /**
    * {@inheritdoc}
    */
+  public function preSave(EntityStorageInterface $storage) {
+    parent::preSave($storage);
+    if (is_null($this->references)) {
+      $this->references = [];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function postSave(EntityStorageInterface $storage, $update = TRUE) {
     parent::postSave($storage, $update);
     \Drupal::service('router.builder')->rebuild();


### PR DESCRIPTION
There were a lot of warnings about various things with missing schema when saving an exo_entity_list, one by one I updated them until the warnings went away. Although I don't know these schemas or this list functionality very well, so please take a look and see if everything makes sense! 