### PR TITLE
Unique id rendering for multiple modal rendering/caching.

### DIFF
--- a/exo_menu/src/ExoMenu.php
+++ b/exo_menu/src/ExoMenu.php
@@ -433,11 +433,12 @@ class ExoMenu implements ExoMenuInterface {
     $style = $this->getPlugin();
     if ($style) {
       $build = $this->buildMenus();
-      $build['#attributes']['id'] = Html::getId('exo-menu-' . $this->id);
+      $id = Html::getUniqueId('exo-menu-' . $this->id);
+      $build['#attributes']['id'] = $id;
       $build['#attached']['drupalSettings']['exoMenu']['defaults'][$this->style] = $style->prepareSettings($this->exoSettings->getSiteSettingsDiff(), 'site');
-      $build['#attached']['drupalSettings']['exoMenu']['menus'][$this->id] = $style->prepareSettings($this->exoSettings->getLocalSettingsDiff(), 'local') + [
+      $build['#attached']['drupalSettings']['exoMenu']['menus'][$id] = $style->prepareSettings($this->exoSettings->getLocalSettingsDiff(), 'local') + [
         'style' => $style->getPluginId(),
-        'selector' => '#' . $build['#attributes']['id'],
+        'selector' => '#' . $id,
       ];
       $build['#wrap_children'] = $this->exoSettings->getSetting('wrap_children');
       $build['#tag'] = $this->tag;

--- a/exo_modal/src/Plugin/ExoModalBlockBase.php
+++ b/exo_modal/src/Plugin/ExoModalBlockBase.php
@@ -381,6 +381,13 @@ abstract class ExoModalBlockBase extends BlockBase implements ExoModalBlockPlugi
     if ($block && $block->access('view')) {
       $this->addCacheableDependency($block);
       $build = $this->entityTypeManager->getViewBuilder('block')->view($block);
+      // Vary the embedded block's render cache by the outer modal so the same
+      // block embedded in multiple modals on one page doesn't reuse cached
+      // output. Without this, render-cache hits replay the first embed's
+      // markup (and any unique IDs in it) for every subsequent embed.
+      if (!empty($build['#cache']['keys']) && !empty($this->configuration['block_id'])) {
+        $build['#cache']['keys'][] = 'exo_modal:' . $this->configuration['block_id'];
+      }
     }
     return $build;
   }


### PR DESCRIPTION
Html::getUniqueId and key drupalSettings by the unique id.

Append outer modal's block_id to embedded block's #cache.keys for unique caching.

Otherwise js will only hit the first render.